### PR TITLE
Fix netavark compilation issues on FreeBSD #1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1245,8 +1245,7 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 [[package]]
 name = "libc"
 version = "0.2.155"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97b3888a4aecf77e811145cadf6eef5901f4782c53886191b2f693f24761847c"
+source = "git+https://github.com/Project-Vacuum/libc.git?rev=376b54d10f65ff8ff76025d0803546261ce70519#376b54d10f65ff8ff76025d0803546261ce70519"
 
 [[package]]
 name = "linux-raw-sys"
@@ -1440,8 +1439,7 @@ dependencies = [
 [[package]]
 name = "netlink-packet-route"
 version = "0.19.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74c171cd77b4ee8c7708da746ce392440cb7bcf618d122ec9ecc607b12938bf4"
+source = "git+https://github.com/Project-Vacuum/netlink-packet-route.git?rev=b1b6a6efcfc3173ba77ef3372985bfc40baabd04#b1b6a6efcfc3173ba77ef3372985bfc40baabd04"
 dependencies = [
  "anyhow",
  "byteorder",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1245,7 +1245,7 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 [[package]]
 name = "libc"
 version = "0.2.155"
-source = "git+https://github.com/Project-Vacuum/libc.git?rev=376b54d10f65ff8ff76025d0803546261ce70519#376b54d10f65ff8ff76025d0803546261ce70519"
+source = "git+https://github.com/Project-Vacuum/libc.git?rev=cc2a58cc37136701343bbd6c688428139ae3c7ee#cc2a58cc37136701343bbd6c688428139ae3c7ee"
 
 [[package]]
 name = "linux-raw-sys"
@@ -1439,7 +1439,8 @@ dependencies = [
 [[package]]
 name = "netlink-packet-route"
 version = "0.19.0"
-source = "git+https://github.com/Project-Vacuum/netlink-packet-route.git?rev=b1b6a6efcfc3173ba77ef3372985bfc40baabd04#b1b6a6efcfc3173ba77ef3372985bfc40baabd04"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74c171cd77b4ee8c7708da746ce392440cb7bcf618d122ec9ecc607b12938bf4"
 dependencies = [
  "anyhow",
  "byteorder",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1245,7 +1245,7 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 [[package]]
 name = "libc"
 version = "0.2.155"
-source = "git+https://github.com/Project-Vacuum/libc.git?rev=cc2a58cc37136701343bbd6c688428139ae3c7ee#cc2a58cc37136701343bbd6c688428139ae3c7ee"
+source = "git+https://github.com/Project-Vacuum/libc.git?rev=98f7a44844859653295f38129c5f3f33f0a7e4fc#98f7a44844859653295f38129c5f3f33f0a7e4fc"
 
 [[package]]
 name = "linux-raw-sys"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,17 +53,17 @@ netlink-sys = "0.8.6"
 tokio = { version = "1.39.1", features = ["rt", "rt-multi-thread", "signal", "fs"] }
 tokio-stream = { version = "0.1.15", features = ["net"] }
 tonic = "0.11"
-mozim = "0.2.4"
 prost = "0.12.6"
 futures-channel = "0.3.30"
 futures-core = "0.3.30"
 futures-util = "0.3.30"
-nispor = "1.2.19"
 tower = { version = "0.4.13" }
 
 [target.'cfg(not(target_os = "freebsd"))'.dependencies]
 iptables = "0.5.2"
 nftables = "0.4.1"
+mozim = "0.2.4"
+nispor = "1.2.19"
 
 [build-dependencies]
 chrono = { version = "0.4.38", default-features = false, features = ["clock"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,6 @@ anyhow = "1.0.86"
 clap = { version = "~4.4.12", features = ["derive", "env"] }
 env_logger = "0.11.5"
 ipnet = { version = "2.9.0", features = ["serde"] }
-iptables = "0.5.2"
 libc = "0.2.154"
 log = "0.4.22"
 serde = { version = "1.0.199", features = ["derive"], optional = true }
@@ -49,7 +48,6 @@ sha2 = "0.10.8"
 netlink-packet-utils = "0.5.2"
 netlink-packet-route = "0.20.1"
 netlink-packet-core = "0.7.0"
-nftables = "0.4.1"
 fs2 = "0.4.3"
 netlink-sys = "0.8.6"
 tokio = { version = "1.39.1", features = ["rt", "rt-multi-thread", "signal", "fs"] }
@@ -62,6 +60,10 @@ futures-core = "0.3.30"
 futures-util = "0.3.30"
 nispor = "1.2.19"
 tower = { version = "0.4.13" }
+
+[target.'cfg(not(target_os = "freebsd"))'.dependencies]
+iptables = "0.5.2"
+nftables = "0.4.1"
 
 [build-dependencies]
 chrono = { version = "0.4.38", default-features = false, features = ["clock"] }

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -2,6 +2,7 @@ use std::ffi::OsString;
 
 use crate::error::{NetavarkError, NetavarkResult};
 
+#[cfg(not(target_os = "freebsd"))]
 pub mod dhcp_proxy;
 pub mod firewalld_reload;
 pub mod setup;

--- a/src/error/mod.rs
+++ b/src/error/mod.rs
@@ -78,10 +78,12 @@ pub enum NetavarkError {
 
     Netlink(netlink_packet_core::error::ErrorMessage),
 
+    #[cfg(not(target_os = "freebsd"))]
     DHCPProxy(tonic::Status),
 
     List(NetavarkErrorList),
 
+    #[cfg(not(target_os = "freebsd"))]
     Nftables(nftables::helper::NftablesError),
 
     SubnetParse(ipnet::AddrParseError),
@@ -153,6 +155,7 @@ impl fmt::Display for NetavarkError {
             NetavarkError::Sysctl(e) => write!(f, "Sysctl error: {e}"),
             NetavarkError::Serde(e) => write!(f, "JSON Decoding error: {e}"),
             NetavarkError::Netlink(e) => write!(f, "Netlink error: {e}"),
+            #[cfg(not(target_os = "freebsd"))]
             NetavarkError::DHCPProxy(e) => write!(f, "dhcp proxy error: {e}"),
             NetavarkError::List(list) => {
                 if list.0.len() == 1 {
@@ -165,6 +168,7 @@ impl fmt::Display for NetavarkError {
                     Ok(())
                 }
             }
+            #[cfg(not(target_os = "freebsd"))]
             NetavarkError::Nftables(e) => write!(f, "nftables error: {e}"),
             NetavarkError::SubnetParse(e) => write!(f, "parsing IP subnet error: {e}"),
             NetavarkError::AddrParse(e) => write!(f, "parsing IP address error: {e}"),
@@ -216,12 +220,14 @@ impl From<netlink_packet_core::error::ErrorMessage> for NetavarkError {
     }
 }
 
+#[cfg(not(target_os = "freebsd"))]
 impl From<tonic::Status> for NetavarkError {
     fn from(err: tonic::Status) -> Self {
         NetavarkError::DHCPProxy(err)
     }
 }
 
+#[cfg(not(target_os = "freebsd"))]
 impl From<nftables::helper::NftablesError> for NetavarkError {
     fn from(err: nftables::helper::NftablesError) -> Self {
         NetavarkError::Nftables(err)

--- a/src/firewall/mod.rs
+++ b/src/firewall/mod.rs
@@ -65,7 +65,7 @@ fn get_firewall_impl(driver_name: Option<String>) -> NetavarkResult<FirewallImpl
                     }
                 };
                 return Ok(FirewallImpl::Firewalld(conn));
-            },
+            }
             #[cfg(not(target_os = "freebsd"))]
             IPTABLES => return Ok(FirewallImpl::Iptables),
             #[cfg(not(target_os = "freebsd"))]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,7 @@ extern crate serde;
 extern crate serde_json;
 
 pub mod commands;
+#[cfg(not(target_os = "freebsd"))]
 pub mod dhcp_proxy;
 pub mod dns;
 pub mod error;

--- a/src/main.rs
+++ b/src/main.rs
@@ -69,7 +69,8 @@ fn main() {
     let aardvark_bin = opts
         .aardvark_binary
         .unwrap_or_else(|| OsString::from("/usr/libexec/podman/aardvark-dns"));
-    let result = match opts.subcmd {
+    let _subcmd = opts.subcmd;
+    let result = match _subcmd {
         SubCommand::Setup(setup) => setup.exec(
             opts.file,
             config,
@@ -91,7 +92,9 @@ fn main() {
         #[cfg(not(target_os = "freebsd"))]
         SubCommand::DHCPProxy(proxy) => dhcp_proxy::serve(proxy),
         #[cfg(target_os = "freebsd")]
-        SubCommand::DHCPProxy => Err(NetavarkError::Message("Command not supported")),
+        SubCommand::DHCPProxy => Err(NetavarkError::Message(format!(
+            "Command not supported - \"{_subcmd}\""
+        ))),
         SubCommand::FirewallDReload => firewalld_reload::listen(config),
     };
 

--- a/src/network/bridge.rs
+++ b/src/network/bridge.rs
@@ -11,11 +11,21 @@ use crate::{
     error::{ErrorWrap, NetavarkError, NetavarkErrorList, NetavarkResult},
     exec_netns,
     firewall::{
-        iptables::MAX_HASH_SIZE,
         state::{remove_fw_config, write_fw_config},
     },
     network::{constants, core_utils::disable_ipv6_autoconf, types},
 };
+
+#[cfg(not(target_os = "freebsd"))]
+use crate::{
+    firewall::{
+        iptables::MAX_HASH_SIZE,
+    },
+};
+
+#[cfg(target_os = "freebsd")]
+/// For now till we have 1st class FreeBSD native firewall(s) support
+const MAX_HASH_SIZE: usize = 13;
 
 use super::{
     constants::{

--- a/src/network/driver.rs
+++ b/src/network/driver.rs
@@ -54,14 +54,14 @@ pub fn get_network_driver<'a>(
     info: DriverInfo<'a>,
     plugins_directories: &Option<Vec<OsString>>,
 ) -> NetavarkResult<Box<dyn NetworkDriver + 'a>> {
-    match info.network.driver.as_str() {
+    let _network_driver = info.network.driver.as_str();
+    match _network_driver {
         constants::DRIVER_BRIDGE => Ok(Box::new(Bridge::new(info))),
         #[cfg(not(target_os = "freebsd"))]
         constants::DRIVER_IPVLAN | constants::DRIVER_MACVLAN => Ok(Box::new(Vlan::new(info))),
         #[cfg(target_os = "freebsd")]
         constants::DRIVER_IPVLAN | constants::DRIVER_MACVLAN => Err(NetavarkError::Message(format!(
-            "Driver not supported - \"{}\"",
-            info.network.driver
+            "Network driver not supported - \"{_network_driver}\""
         ))),
 
         name => {
@@ -77,8 +77,7 @@ pub fn get_network_driver<'a>(
             }
 
             Err(NetavarkError::Message(format!(
-                "unknown network driver \"{}\"",
-                info.network.driver
+                "unknown network driver \"{_network_driver}\""
             )))
         }
     }

--- a/src/network/mod.rs
+++ b/src/network/mod.rs
@@ -15,9 +15,11 @@ pub mod constants;
 pub mod core_utils;
 pub mod driver;
 pub mod internal_types;
+#[cfg(not(target_os = "freebsd"))]
 mod macvlan_dhcp;
 pub mod netlink;
 pub mod plugin;
+#[cfg(not(target_os = "freebsd"))]
 pub mod vlan;
 
 impl types::NetworkOptions {


### PR DESCRIPTION
- Reorganise dependencies
- Add limited support for netlink on FreeBSD 13 and later, initially aiming to support functionality required by the netavark container networking manager
